### PR TITLE
fix(npm_deprecate_package): использует `secrets` вместо `inputs` для передачи токена

### DIFF
--- a/.github/workflows/npm_deprecate_package.yml
+++ b/.github/workflows/npm_deprecate_package.yml
@@ -14,7 +14,8 @@ on:
       reason:
         description: 'reason for deprecation (only latin supported)'
         required: true
-      auth_token:
+    secrets:
+      npm_auth_token:
         description: 'npm auth token'
         required: true
 
@@ -30,6 +31,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Deprecate version
-        run: npm deprecate "${{ github.event.inputs.package }}@${{ github.event.inputs.version }}" "${{ github.event.inputs.reason }}"
+        run: npm deprecate "${{ inputs.package }}@${{ inputs.version }}" "${{ inputs.reason }}"
         env:
-          NODE_AUTH_TOKEN: ${{ github.event.inputs.auth_token }}
+          NODE_AUTH_TOKEN: ${{ secrets.npm_auth_token }}


### PR DESCRIPTION
- Вместо `inputs.auth_token` используем [secrets.npm_auth_token](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecrets).
- Удалил получение `inputs` из `github.event.*` – можно брать напрямую.

### Воспроизведение

https://github.com/VKCOM/icons/actions/runs/3996488054

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/214315364-5a8f5a3e-7224-4765-935c-844f9137ca85.png">

---

- caused by #1
- [Action doesn't understand the 'secrets' syntax copied from the documentation #27054](https://github.com/orgs/community/discussions/27054)