### PR TITLE
fix(npm_deprecate_package): исправляет ошибку валидации

### DIFF
--- a/.github/workflows/npm_deprecate_package.yml
+++ b/.github/workflows/npm_deprecate_package.yml
@@ -1,17 +1,20 @@
-author: '@VKCOM/VKUI-core'
+# See https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions
+# @author @VKCOM/VKUI-core
 name: 'Deprecate NPM package'
-description: 'See https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions'
 
 on:
   workflow_call:
     inputs:
       package:
+        type: 'string'
         description: 'package`s name'
         required: true
       version:
+        type: 'string'
         description: 'type version: x.y.z (without "v")'
         required: true
       reason:
+        type: 'string'
         description: 'reason for deprecation (only latin supported)'
         required: true
     secrets:


### PR DESCRIPTION
Поля `author` и `description` невалидны 😅😅😅

https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions 

> **Tip:** GitHub редактор умеет валидировать yml файлы воркфлоу
>
> <img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/214349871-cc4c9e85-3d90-4e51-8cbc-ae69c09e1cda.png">

### Воспроизведение

https://github.com/VKCOM/icons/actions/runs/3997990000

---

- caused by #1